### PR TITLE
moved event functions to appropriate classes

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -161,34 +161,6 @@ class ELGSDApi {
 	}
 
 	/**
-	 * Request the actions's persistent data. StreamDeck does not return the data, but trigger the actions's didReceiveSettings event
-	 * @param {string} [context]
-	 */
-	getSettings(context) {
-		this.send(context ?? this.uuid, Events.getSettings);
-	}
-
-	/**
-	 * Save the actions's persistent data.
-	 * @param context
-	 * @param {object} payload
-	 */
-	setSettings(context, payload) {
-		this.send(context ?? this.uuid, Events.setSettings, {
-			action: this?.actionInfo?.action,
-			payload: payload || null,
-			targetContext: context,
-		});
-	}
-
-	/**
-	 * Request the plugin's persistent data. StreamDeck does not return the data, but trigger the plugin/property inspectors didReceiveGlobalSettings event
-	 */
-	getGlobalSettings() {
-		this.send(this.uuid, Events.getGlobalSettings);
-	}
-
-	/**
 	 * Save the plugin's persistent data
 	 * @param {object} payload
 	 */
@@ -215,32 +187,6 @@ class ELGSDApi {
 	}
 
 	/**
-	 * Send payload from the property inspector to the plugin
-	 * @param {string} context
-	 * @param {object} payload
-	 */
-	sendToPlugin(context, payload) {
-		this.send(this.uuid, Events.sendToPlugin, {
-			action: this?.actionInfo?.action,
-			payload: payload || null,
-			targetContext: context,
-		});
-	}
-
-	/**
-	 * Switches to a readonly profile or returns to previous profile
-	 * @param {string} device
-	 * @param {string} [profile]
-	 */
-	switchToProfile(device, profile) {
-		if (!device) {
-			console.error('A device id is required for switchToProfile.');
-		}
-
-		this.send(this.uuid, Events.switchToProfile, { device, payload: { profile } });
-	}
-
-	/**
 	 * Registers a callback function for when Stream Deck is connected
 	 * @param {function} fn
 	 * @returns ELGSDStreamDeck
@@ -251,37 +197,6 @@ class ELGSDApi {
 		}
 
 		this.on(Events.connected, (jsn) => fn(jsn));
-		return this;
-	}
-
-	/**
-	 * Registers a callback function for the didReceiveGlobalSettings event, which fires when calling getGlobalSettings
-	 * @param {function} fn
-	 */
-	onDidReceiveGlobalSettings(fn) {
-		if (!fn) {
-			console.error(
-				'A callback function for the didReceiveGlobalSettings event is required for onDidReceiveGlobalSettings.'
-			);
-		}
-
-		this.on(Events.didReceiveGlobalSettings, (jsn) => fn(jsn));
-		return this;
-	}
-
-	/**
-	 * Registers a callback function for the didReceiveSettings event, which fires when calling getSettings
-	 * @param {string} action
-	 * @param {function} fn
-	 */
-	onDidReceiveSettings(action, fn) {
-		if (!fn) {
-			console.error(
-				'A callback function for the didReceiveSettings event is required for onDidReceiveSettings.'
-			);
-		}
-
-		this.on(`${action}.${Events.didReceiveSettings}`, (jsn) => fn(jsn));
 		return this;
 	}
 }

--- a/js/dynamic-styles.js
+++ b/js/dynamic-styles.js
@@ -8,7 +8,7 @@ const fadeColor = function (col, amt) {
 	return '#' + (g | (b << 8) | (r << 16)).toString(16).padStart(6, 0);
 };
 
-$SD.onConnected(({appInfo}) => {
+$PI.onConnected(({appInfo}) => {
 	if (!appInfo?.colors) return;
 	const clrs = appInfo.colors;
 	const node = document.getElementById('#sdpi-dynamic-styles') || document.createElement('style');

--- a/js/property-inspector.js
+++ b/js/property-inspector.js
@@ -31,9 +31,31 @@ class ELGSDPropertyInspector extends ELGSDApi {
 		this.on(`${actionUUID}.${Events.sendToPropertyInspector}`, (jsn) => fn(jsn));
 		return this;
 	}
+
+	/**
+	 * Send payload from the property inspector to the plugin
+	 * @param {object} payload
+	 */
+	sendToPlugin(payload) {
+		this.send(this.uuid, Events.sendToPlugin, {
+			action: this?.actionInfo?.action,
+			payload: payload || null,
+		});
+	}
+
+	/**
+	 * Save the actions's persistent data.
+	 * @param {object} payload
+	 */
+	setSettings(payload) {
+		this.send(this.uuid, Events.setSettings, {
+			action: this?.actionInfo?.action,
+			payload: payload || null,
+		});
+	}
 }
 
-const $SD = new ELGSDPropertyInspector();
+const $PI = new ELGSDPropertyInspector();
 
 /**
  * connectElgatoStreamDeckSocket
@@ -46,5 +68,5 @@ const $SD = new ELGSDPropertyInspector();
  * @param {string} actionInfo - Context is an internal identifier used to communicate to the host application.
  */
 function connectElgatoStreamDeckSocket(port, uuid, messageType, appInfoString, actionInfo) {
-	$SD.connect(port, uuid, messageType, appInfoString, actionInfo);
+	$PI.connect(port, uuid, messageType, appInfoString, actionInfo);
 }

--- a/js/stream-deck.js
+++ b/js/stream-deck.js
@@ -43,6 +43,65 @@ class ELGSDStreamDeck extends ELGSDApi {
 	}
 
 	/**
+	 * Save the actions's persistent data.
+	 * @param context
+	 * @param {object} payload
+	 */
+	setSettings(context, payload) {
+		this.send(context, Events.setSettings, {
+			action: this?.actionInfo?.action,
+			payload: payload || null,
+			targetContext: context,
+		});
+	}
+
+	/**
+	 * Request the actions's persistent data. StreamDeck does not return the data, but trigger the actions's didReceiveSettings event
+	 * @param {string} [context]
+	 */
+	 getSettings(context) {
+		this.send(context, Events.getSettings);
+	}
+
+	/**
+	 * Request the plugin's persistent data. StreamDeck does not return the data, but trigger the plugin/property inspectors didReceiveGlobalSettings event
+	 */
+	 getGlobalSettings() {
+		this.send(this.uuid, Events.getGlobalSettings);
+	}
+
+	/**
+	 * Registers a callback function for the didReceiveGlobalSettings event, which fires when calling getGlobalSettings
+	 * @param {function} fn
+	 */
+	 onDidReceiveGlobalSettings(fn) {
+		if (!fn) {
+			console.error(
+				'A callback function for the didReceiveGlobalSettings event is required for onDidReceiveGlobalSettings.'
+			);
+		}
+
+		this.on(Events.didReceiveGlobalSettings, (jsn) => fn(jsn));
+		return this;
+	}
+
+	/**
+	 * Registers a callback function for the didReceiveSettings event, which fires when calling getSettings
+	 * @param {string} action
+	 * @param {function} fn
+	 */
+	onDidReceiveSettings(action, fn) {
+		if (!fn) {
+			console.error(
+				'A callback function for the didReceiveSettings event is required for onDidReceiveSettings.'
+			);
+		}
+
+		this.on(`${action}.${Events.didReceiveSettings}`, (jsn) => fn(jsn));
+		return this;
+	}
+
+	/**
 	 * Set the state of the actions
 	 * @param {string} context
 	 * @param {number} [state]
@@ -222,6 +281,19 @@ class ELGSDStreamDeck extends ELGSDApi {
 
 		this.on(Events.systemDidWakeUp, (jsn) => fn(jsn));
 		return this;
+	}
+
+	/**
+	 * Switches to a readonly profile or returns to previous profile
+	 * @param {string} device
+	 * @param {string} [profile]
+	 */
+	 switchToProfile(device, profile) {
+		if (!device) {
+			console.error('A device id is required for switchToProfile.');
+		}
+
+		this.send(this.uuid, Events.switchToProfile, { device, payload: { profile } });
 	}
 }
 


### PR DESCRIPTION
Some events cannot be called from the Property Inspector, so they moved to the Stream Deck class instead of the parent class. `$SD` was renamed to `$PI` in the property-inspector.js. This is a breaking change, but it fixes intellisense by not have an overlapping `$SD` variable name.